### PR TITLE
Cache itemHandler.getSlots()

### DIFF
--- a/capability/itemhandler/ItemHandlerItemStackIterator.java
+++ b/capability/itemhandler/ItemHandlerItemStackIterator.java
@@ -13,10 +13,13 @@ import java.util.NoSuchElementException;
 public class ItemHandlerItemStackIterator implements Iterator<ItemStack> {
 
     private final IItemHandler itemHandler;
+    private final int maxSlots;
     private int slot;
 
     public ItemHandlerItemStackIterator(IItemHandler itemHandler, int offset) {
         this.itemHandler = itemHandler;
+        // Cache the total slot count, since it can be an expensive operation on composite inventories
+        this.maxSlots = itemHandler.getSlots();
         this.slot = offset;
     }
 
@@ -26,7 +29,7 @@ public class ItemHandlerItemStackIterator implements Iterator<ItemStack> {
 
     @Override
     public boolean hasNext() {
-        return slot < itemHandler.getSlots();
+        return slot < maxSlots;
     }
 
     @Override


### PR DESCRIPTION
IItemHandler.getSlots() can be a pretty expensive operation if you have a composite inventory like Actually Additions' [Item Interface](https://github.com/Ellpeck/ActuallyAdditions/blob/master/src/main/java/de/ellpeck/actuallyadditions/mod/tile/TileEntityItemViewer.java#L54-L70).
Calling that in a loop can quickly shoot CPU usage through the roof.